### PR TITLE
Streamline CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.16.x, 1.19.x]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go


### PR DESCRIPTION
This package has no complicated code or dependencies hence is does not makes sense to explicitly test against Windows and Mac environments. This is simply saves time, resources and energy :)

Add support for Go 19.x and keep supporting 16.x for some more time as it was a major milestone too.