### PR TITLE
Rename NewText to New

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -13,32 +13,32 @@ func ExampleText() {
 	// Output: *****
 }
 
-func ExampleNewText() {
-	s := secret.NewText("$ecre!")
+func ExampleNew() {
+	s := secret.New("$ecre!")
 	fmt.Println(s, s.Value())
 	// Output: ***** $ecre!
 }
 
 func ExampleFiveXs() {
-	s := secret.NewText("$ecre!", secret.FiveXs)
+	s := secret.New("$ecre!", secret.FiveXs)
 	fmt.Println(s, s.Value())
 	// Output: XXXXX $ecre!
 }
 
 func ExampleRedacted() {
-	s := secret.NewText("$ecre!", secret.Redacted)
+	s := secret.New("$ecre!", secret.Redacted)
 	fmt.Println(s, s.Value())
 	// Output: [REDACTED] $ecre!
 }
 
 func ExampleCustomRedact() {
-	s := secret.NewText("$ecre!", secret.CustomRedact("HIDDEN"))
+	s := secret.New("$ecre!", secret.CustomRedact("HIDDEN"))
 	fmt.Println(s, s.Value())
 	// Output: HIDDEN $ecre!
 }
 
 func ExampleText_MarshalText() {
-	sec := secret.NewText("secret!")
+	sec := secret.New("secret!")
 	bytes, err := sec.MarshalText()
 	if err != nil {
 		panic(err)
@@ -66,7 +66,7 @@ func ExampleText_MarshalJSON() {
 		Password secret.Text
 	}{
 		User:     "John",
-		Password: secret.NewText("shh!"),
+		Password: secret.New("shh!"),
 	}
 
 	bytes, err := json.Marshal(&login)
@@ -97,9 +97,9 @@ func ExampleText_UnmarshalJSON() {
 }
 
 func ExampleText_Equals() {
-	s1 := secret.NewText("hello")
-	s2 := secret.NewText("hello")
-	s3 := secret.NewText("hi")
+	s1 := secret.New("hello")
+	s2 := secret.New("hello")
+	s3 := secret.New("hi")
 	fmt.Println(s1.Equals(s2))
 	fmt.Println(s1.Equals(s3))
 	// Output:

--- a/secret.go
+++ b/secret.go
@@ -22,9 +22,9 @@ type Text struct {
 	r *string
 }
 
-// NewText creates a new Text instance with s as the secret value. Multiple option functions can
+// New creates a new Text instance with s as the secret value. Multiple option functions can
 // be passed to alter default behavior.
-func NewText(s string, options ...func(*Text)) Text {
+func New(s string, options ...func(*Text)) Text {
 	sec := Text{
 		v: new(string),
 		r: new(string),
@@ -71,9 +71,9 @@ func (s *Text) UnmarshalText(b []byte) error {
 
 	// If the original redact is not nil then use it otherwise fallback to default.
 	if s.r != nil {
-		*s = NewText(v, CustomRedact(*s.r))
+		*s = New(v, CustomRedact(*s.r))
 	} else {
-		*s = NewText(v)
+		*s = New(v)
 	}
 	return nil
 }
@@ -95,9 +95,9 @@ func (s *Text) UnmarshalJSON(b []byte) error {
 
 	// If the original redact is not nil then use it otherwise fallback to default.
 	if s.r != nil {
-		*s = NewText(n, CustomRedact(*s.r))
+		*s = New(n, CustomRedact(*s.r))
 	} else {
-		*s = NewText(n)
+		*s = New(n)
 	}
 
 	return nil

--- a/secret_test.go
+++ b/secret_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestText_UnmarshalJSON_allocates_new_data_rather_than_overwriting_existing(t *testing.T) {
-	s1 := NewText("hello")
+	s1 := New("hello")
 
 	oldRedact := s1.r
 	oldValue := s1.v


### PR DESCRIPTION
Older name was unnecessarily adding type name to the function which is not a good practice as per common Go standards.

See https://dave.cheney.net/practical-go/presentations/gophercon-israel.html#_a_variables_name_should_describe_its_contents