### PR TITLE
Convert equality check from method to a function

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -75,12 +75,12 @@ func ExampleText_UnmarshalText() {
 	// $ecre!
 }
 
-func ExampleText_Equals() {
-	s1 := secret.New("hello")
-	s2 := secret.New("hello")
-	s3 := secret.New("hi")
-	fmt.Println(s1.Equals(s2))
-	fmt.Println(s1.Equals(s3))
+func ExampleEqual() {
+	tx1 := secret.New("hello")
+	tx2 := secret.New("hello", secret.RedactHint(secret.Redacted))
+	tx3 := secret.New("world")
+	fmt.Println(secret.Equal(tx1, tx2))
+	fmt.Println(secret.Equal(tx1, tx3))
 
 	// Output:
 	// true


### PR DESCRIPTION
The equality check is a readonly operation on Text values hence it is more of a package function candidate rather than a method on the type itself.